### PR TITLE
Terra run task token

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
       * [Features:](#features)
       * [Improvements:](#improvements)
 
-<!-- Added by: root, at: Wed Aug 17 06:19:47 UTC 2022 -->
+<!-- Added by: root, at: Wed Aug 17 21:24:41 UTC 2022 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
       * [Features:](#features)
       * [Improvements:](#improvements)
 
-<!-- Added by: root, at: Fri Aug 12 05:37:49 UTC 2022 -->
+<!-- Added by: root, at: Wed Aug 17 06:02:24 UTC 2022 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
       * [Features:](#features)
       * [Improvements:](#improvements)
 
-<!-- Added by: root, at: Wed Aug 17 06:02:24 UTC 2022 -->
+<!-- Added by: root, at: Wed Aug 17 06:19:47 UTC 2022 -->
 
 <!--te-->
 

--- a/docker/src/terra_run/run.py
+++ b/docker/src/terra_run/run.py
@@ -118,7 +118,7 @@ def main() -> None:
         log.error(e, exc_info=True)
         state = "failure"
 
-    sf = boto3.client("stepfunction")
+    sf = boto3.client("stepfunctions")
     log_url = get_task_log_url()
     output = json.dumps({"LogsUrl": log_url})
     if state == "success":

--- a/docker/src/terra_run/run.py
+++ b/docker/src/terra_run/run.py
@@ -114,13 +114,14 @@ def main() -> None:
         log.error(e, exc_info=True)
         state = "failure"
 
-    sf = boto3.client("stepfunctions")
     log_url = get_task_log_url()
-    output = json.dumps({"LogsUrl": log_url})
+    sf = boto3.client("stepfunctions")
+
     if state == "success":
+        output = json.dumps({"LogsUrl": log_url})
         sf.send_task_success(taskToken=os.environ["TASK_TOKEN"], output=output)
     else:
-        sf.send_task_failure(taskToken=os.environ["TASK_TOKEN"], output=output)
+        sf.send_task_failure(taskToken=os.environ["TASK_TOKEN"])
 
     try:
         send = json.loads(os.environ["COMMIT_STATUS_CONFIG"])[os.environ["STATE_NAME"]]

--- a/docker/src/terra_run/run.py
+++ b/docker/src/terra_run/run.py
@@ -12,7 +12,6 @@ sys.path.append(os.path.dirname(__file__) + "/..")
 from common.utils import (
     subprocess_run,
     send_commit_status,
-    ServerException,
     get_task_log_url,
 )
 
@@ -111,9 +110,6 @@ def main() -> None:
     try:
         if os.environ["STATE_NAME"] == "Apply":
             update_new_resources()
-    except KeyError as e:
-        log.error(e, exc_info=True)
-        ServerException("Env var: `STATE_NAME` is not passed from Step Function")
     except Exception as e:
         log.error(e, exc_info=True)
         state = "failure"

--- a/functions/approval_request/lambda_function.py
+++ b/functions/approval_request/lambda_function.py
@@ -62,8 +62,7 @@ def lambda_handler(event, context):
 
     template_data = {
         "path": msg["Path"],
-        "logs_url": msg["LogUrlPrefix"]
-        + aws_encode(msg["LogStreamPrefix"] + msg["PlanTaskArn"].split("/")[-1]),
+        "logs_url": msg["LogsUrl"],
         "execution_name": msg["ExecutionName"],
         "account_name": msg["AccountName"],
         "pr_id": msg["PullRequestID"],

--- a/main.tf
+++ b/main.tf
@@ -51,17 +51,18 @@ resource "aws_sfn_state_machine" "this" {
                       "Name"    = "TG_COMMAND"
                       "Value.$" = "$.plan_command"
                     },
+                    {
+                      "Name"    = "TASK_TOKEN"
+                      "Value.$" = "$$.Task.Token"
+                    },
                   ]
                 )
               }
             ]
           }
         }
-        Resource = "arn:aws:states:::ecs:runTask.sync"
-        Type     = "Task"
-        ResultSelector = {
-          "PlanTaskArn.$" = "$.TaskArn"
-        }
+        Resource   = "arn:aws:states:::ecs:runTask.sync"
+        Type       = "Task"
         ResultPath = "$.PlanOutput"
         Catch = [
           {
@@ -85,9 +86,7 @@ resource "aws_sfn_state_machine" "this" {
             "ExecutionName.$"   = "$$.Execution.Name"
             "AccountName.$"     = "$.account_name"
             "PullRequestID.$"   = "$.pr_id"
-            "PlanTaskArn.$"     = "$.PlanOutput.PlanTaskArn"
-            "LogUrlPrefix"      = local.log_url_prefix
-            "LogStreamPrefix"   = local.log_stream_prefix
+            "PlanOutput"        = "$.PlanOutput"
           }
         }
         Resource   = "arn:aws:states:::sns:publish.waitForTaskToken"
@@ -170,7 +169,11 @@ resource "aws_sfn_state_machine" "this" {
                     {
                       "Name"  = "METADB_SECRET_ARN"
                       "Value" = aws_secretsmanager_secret_version.ci_metadb_user.arn
-                    }
+                    },
+                    {
+                      "Name"    = "TASK_TOKEN"
+                      "Value.$" = "$$.Task.Token"
+                    },
                   ]
                 )
               }

--- a/tests/unit/docker/test_terra_run.py
+++ b/tests/unit/docker/test_terra_run.py
@@ -158,15 +158,20 @@ def test_update_new_resources(mock_get_new_provider_resources, conn, resources):
     {
         "TG_COMMAND": "",
         "COMMIT_STATUS_CONFIG": json.dumps({"Plan": True, "Apply": True}),
+        "TASK_TOKEN": "token-123",
     },
 )
+@patch("docker.src.terra_run.run.get_task_log_url")
 @patch("docker.src.terra_run.run.send_commit_status")
 @patch("docker.src.terra_run.run.update_new_resources")
 @patch("subprocess.run")
+@patch("boto3.client")
 def test_main(
+    mock_boto3_client,
     mock_subprocess,
     mock_update_new_resources,
     mock_send_commit_status,
+    mock_get_task_log_url,
     state_name,
     expected_status,
     run_side_effect,
@@ -177,6 +182,8 @@ def test_main(
 
     mock_subprocess.side_effect = run_side_effect
     mock_update_new_resources.side_effect = update_new_resources_side_effect
+    log_url = "mock-url"
+    mock_get_task_log_url.return_value = log_url
 
     main()
-    assert mock_send_commit_status.call_args_list == [call(expected_status)]
+    assert mock_send_commit_status.call_args_list == [call(expected_status, log_url)]

--- a/tests/unit/functions/test_approval_request.py
+++ b/tests/unit/functions/test_approval_request.py
@@ -28,9 +28,7 @@ event = {
                         "StateMachineArn": "mock-state-machine-arn",
                         "TaskToken": "mock-token",
                         "PullRequestID": "1",
-                        "LogUrlPrefix": "mock-log-prefix",
-                        "LogStreamPrefix": "mock-stream-prefix",
-                        "PlanTaskArn": "mock-arn",
+                        "LogsUrl": "mock-log-url",
                     }
                 )
             }


### PR DESCRIPTION
Fixes issue https://github.com/marshall7m/terraform-aws-infrastructure-live-ci/issues/7

- Adds task token to Terra Run ECS tasks
- Task will send either a success or failure task token depending on the status of the task
- Task token output contains the Terra Run's associated CloudWatch log URL so the approval request Lambda Function doesn't have to formulate the URL within its execution time