### PR TITLE
Replace psycopg2 mocks with local aurora container endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+LOCAL_METAB_PORT=8080
+METADB_CLUSTER_ARN=arn:aws:rds:us-east-1:123456789012:cluster:dummy
+METADB_SECRET_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy
+METADB_NAME=postgres

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,22 +73,22 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - name: mask sensitive
-        run: |
-          echo "::add-mask::$TF_VAR_testing_unit_github_token"
+    - uses: actions/checkout@v3
+    - name: mask sensitive
+      run: |
+        echo "::add-mask::$TF_VAR_testing_unit_github_token"
 
-      - name: Configure AWS Credentials for remote workflow
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ env.AWS_REGION }}
+    - name: Configure AWS Credentials for remote workflow
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        aws-region: ${{ env.AWS_REGION }}
 
-      - name: Tests
-        id: act_pytest_unit
-        shell: bash
-        run: |
-          docker compose run unit pytest -vv tests/unit
+    - name: Tests
+      id: act_pytest_unit
+      shell: bash
+      run: |
+        docker compose run unit pytest -vv tests/unit
 
   integration:
     needs: [precommit, unit]
@@ -101,7 +101,7 @@ jobs:
       if: ${{ env.ACT }}
       run: |
         docker compose run integration pytest -vv tests/integration
-  
+
   e2e:
     needs: [precommit, unit]
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,7 @@ jobs:
     env:
       TF_VAR_testing_unit_github_token: ${{ secrets.TF_VAR_TESTING_UNIT_GITHUB_TOKEN }}
       TF_VAR_approval_request_sender_email: ${{ secrets.TF_VAR_APPROVAL_REQUEST_SENDER_EMAIL }}
+      LOCAL_METAB_PORT: 8080
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,20 +65,8 @@ jobs:
   unit:
     needs: precommit
     runs-on: ubuntu-latest
-    container: ghcr.io/marshall7m/terrace:v0.1.11
-    services:
-      postgres:
-        image: postgres:10.14-alpine
-        env:
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       TF_VAR_testing_unit_github_token: ${{ secrets.TF_VAR_TESTING_UNIT_GITHUB_TOKEN }}
-      TF_VAR_approval_request_sender_email: ${{ secrets.TF_VAR_APPROVAL_REQUEST_SENDER_EMAIL }}
       LOCAL_METAB_PORT: 8080
     permissions:
       id-token: write
@@ -88,57 +76,16 @@ jobs:
       - name: mask sensitive
         run: |
           echo "::add-mask::$TF_VAR_testing_unit_github_token"
-          echo "::add-mask::$TF_VAR_approval_request_sender_email"
 
       - name: Configure AWS Credentials for remote workflow
         uses: aws-actions/configure-aws-credentials@v1
-        if: ${{ !env.ACT }}
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Configure AWS Credentials for local workflow
-        uses: aws-actions/configure-aws-credentials@v1
-        if: ${{ env.ACT }}
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
-          aws-region: ${{ env.AWS_REGION }}
-
-      - uses: actions/setup-python@v3
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-          architecture: x64
-
-      - name: Tests
-        id: pytest_unit
-        shell: bash
-        if: ${{ !env.ACT }}
-        env:
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          PGDATABASE: postgres
-          PGHOST: postgres
-          PGPORT: 5432
-        run: |
-          export PYTHONPATH=$PWD/functions:$PYTHONPATH
-          source $VIRTUAL_ENV/bin/activate
-          python3 -m pip install -e ".[unit]"
-          pytest -vv tests/unit
-
-      - name: Install Docker
-        id: unit_install_docker
-        shell: bash
-        if: ${{ env.ACT }} 
-        run: |
-          bash ./runner_install_docker.sh
-
-      # using docker compose workaround until nektos/act handles services properly. See issue: https://github.com/nektos/act/issues/173
       - name: Tests
         id: act_pytest_unit
         shell: bash
-        if: ${{ env.ACT }} 
         run: |
           docker compose run unit pytest -vv tests/unit
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TF_VAR_testing_unit_github_token: ${{ secrets.TF_VAR_TESTING_UNIT_GITHUB_TOKEN }}
-      LOCAL_METAB_PORT: 8080
     permissions:
       id-token: write
       contents: read

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
       * [Features:](#features)
       * [Improvements:](#improvements)
 
-<!-- Added by: root, at: Fri Aug 26 00:46:29 UTC 2022 -->
+<!-- Added by: root, at: Fri Aug 26 18:32:06 UTC 2022 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
       * [Features:](#features)
       * [Improvements:](#improvements)
 
-<!-- Added by: root, at: Fri Aug 26 00:10:16 UTC 2022 -->
+<!-- Added by: root, at: Fri Aug 26 00:46:29 UTC 2022 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
       * [Features:](#features)
       * [Improvements:](#improvements)
 
-<!-- Added by: root, at: Thu Aug 18 19:55:34 UTC 2022 -->
+<!-- Added by: root, at: Fri Aug 26 00:10:16 UTC 2022 -->
 
 <!--te-->
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,13 +38,13 @@ services:
     image: koxudaxi/local-data-api:0.6.12
     restart: always
     environment:
-    - ENGINE=PostgreSQLJDBC
-    - PGHOST=postgres
-    - PGPORT=5432
-    - PGUSER=postgres
-    - PGPASSWORD=postgres
-    - RESOURCE_ARN=arn:aws:rds:us-west-2:123456789012:cluster:dummy
-    - SECRET_ARN=arn:aws:secretsmanager:us-west-2:123456789012:secret:dummy
+    - ENGINE=PostgresSQL
+    - POSTGRES_HOST=postgres
+    - POSTGRES_PORT=5432
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=postgres
+    - RESOURCE_ARN=${METADB_CLUSTER_ARN}
+    - SECRET_ARN=${METADB_SECRET_ARN}
     ports:
     - 8080:80
     profiles: [unit, integration]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - 5432:5432
     environment:
       - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=postgres
     deploy:
       restart_policy:
         condition: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: "3.8"
 services:
+
   postgres:
     image: postgres:10.14-alpine
+    restart: always
     container_name: postgres
     volumes:
       - "$PWD/docker-pgsql-entrypoint:/docker-entrypoint-initdb.d"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,15 +40,17 @@ services:
       profiles: ["unit"]
 
   unit:
+    network_mode: host
     stdin_open: true
     tty: true
-    image: ghcr.io/marshall7m/terrace:v0.1.11
+    image: terraform-aws-infrastructure-live/unit
+    build: ./tests/unit
     volumes:
       - "$PWD:/src"
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
-      - AWS_REGION
+      - AWS_REGION=us-west-2
       - AWS_DEFAULT_REGION
       - AWS_SESSION_TOKEN
       - AWS_SESSION_EXPIRATION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,22 @@ services:
       retries: 50
     profiles: ["unit"]
 
+  local-data-api:
+
+      image: koxudaxi/local-data-api:0.6.12
+      restart: always
+      environment:
+        - ENGINE=PostgresSQL
+        - POSTGRES_HOST=postgres
+        - POSTGRES_PORT=5432
+        - POSTGRES_USER=postgres
+        - POSTGRES_PASSWORD=postgres
+        - RESOURCE_ARN=${METADB_CLUSTER_ARN}
+        - SECRET_ARN=${METADB_SECRET_ARN}
+      ports:
+        - 8080:80
+      profiles: ["unit"]
+
   unit:
     stdin_open: true
     tty: true
@@ -41,9 +57,14 @@ services:
       - PGDATABASE=postgres
       - PGHOST=postgres
       - PGPORT=5432
+      - METADB_CLUSTER_ARN=${METADB_CLUSTER_ARN}
+      - METADB_NAME=${METADB_NAME}
+      - METADB_SECRET_ARN=${METADB_SECRET_ARN}
+      - LOCAL_METAB_PORT=${LOCAL_METAB_PORT}
     entrypoint: ["/bin/bash", "entrypoint.sh"]
     profiles: ["unit"]
     depends_on:
+      - local-data-api
       - postgres
 
   e2e:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 version: '3.8'
 services:
-
   postgres:
     image: postgres:10.14-alpine
     restart: always
@@ -11,8 +10,8 @@ services:
     ports:
     - 5432:5432
     environment:
-      - POSTGRES_PASSWORD=postgres
-      - POSTGRES_DB=postgres
+    - POSTGRES_PASSWORD=postgres
+    - POSTGRES_DB=postgres
     deploy:
       restart_policy:
         condition: on-failure
@@ -48,23 +47,7 @@ services:
     - SECRET_ARN=arn:aws:secretsmanager:us-west-2:123456789012:secret:dummy
     ports:
     - 8080:80
-    profiles: [integration]
-
-  local-data-api:
-
-      image: koxudaxi/local-data-api:0.6.12
-      restart: always
-      environment:
-        - ENGINE=PostgresSQL
-        - POSTGRES_HOST=postgres
-        - POSTGRES_PORT=5432
-        - POSTGRES_USER=postgres
-        - POSTGRES_PASSWORD=postgres
-        - RESOURCE_ARN=${METADB_CLUSTER_ARN}
-        - SECRET_ARN=${METADB_SECRET_ARN}
-      ports:
-        - 8080:80
-      profiles: ["unit"]
+    profiles: [unit, integration]
 
   unit:
     network_mode: host
@@ -92,11 +75,11 @@ services:
     - METADB_NAME=${METADB_NAME}
     - METADB_SECRET_ARN=${METADB_SECRET_ARN}
     - LOCAL_METAB_PORT=${LOCAL_METAB_PORT}
-    entrypoint: ["/bin/bash", "entrypoint.sh"]
-    profiles: ["unit"]
+    entrypoint: [/bin/bash, entrypoint.sh]
+    profiles: [unit]
     depends_on:
-      - local-data-api
-      - postgres
+    - local-data-api
+    - postgres
 
   integration:
     network_mode: host
@@ -121,7 +104,7 @@ services:
     - postgres
     - sf-local
     - local-data-api
- 
+
   e2e:
     stdin_open: true
     tty: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,6 @@ fi
 
 
 source "$VIRTUAL_ENV"/bin/activate
-python3 -m pip install ".[all]"
 python3 -m pip install -e /src
 
 exec "$@"

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -91,13 +91,13 @@ def local_execute(query, fetch_one=False, return_dict=False):
                     ]
 
 
-def toggle_trigger(table, trigger, enable=False):
+def toggle_trigger(table: str, trigger: str, enable=False):
     """
     Toggles the tables associated testing trigger that creates random defaults to prevent any null violations
 
     Arguments:
-        conn: Database connection object
         table: Table to insert the records into
+        trigger: Trigger to enable/disable
         enable: Enables the table's associated trigger
     """
 
@@ -122,8 +122,8 @@ def insert_records(table, records, enable_defaults=None):
     Toggles table's associated trigger and inserts list of dictionaries or a single dictionary into the table
 
     Arguments:
-        conn: Database connection object
         table: Table to insert the records into
+        records: List of dictionaries or a single dictionary containing record(s) to insert
         enable_defaults: Enables the table's associated trigger that inputs default values
     """
     if type(records) == dict:

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -139,6 +139,14 @@ def insert_records(table, records, enable_defaults=None):
             cols = record.keys()
             log.info("Inserting record(s)")
             log.info(record)
+            values = []
+            for val in record.values():
+                if type(val) == str:
+                    values.append(f"'{val}'")
+                elif type(val) == list:
+                    values.append("'{" + ", ".join(val) + "}'")
+                else:
+                    values.append(str(val))
             query = """
             INSERT INTO {tbl} ({fields})
             VALUES({values})
@@ -146,9 +154,7 @@ def insert_records(table, records, enable_defaults=None):
             """.format(
                 tbl=table,
                 fields=", ".join(cols),
-                values=", ".join(
-                    [f"'{val}'" if type(val) == str else val for val in record]
-                ),
+                values=", ".join(values),
             )
 
             log.debug(f"Running: {query}")

--- a/tests/unit/Dockerfile
+++ b/tests/unit/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/marshall7m/terrace:v0.1.11
+COPY requirements.txt ./requirements.txt
+RUN python3 -m pip install -r requirements.txt

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,69 +1,54 @@
 import pytest
-import psycopg2
-from psycopg2 import sql
 import os
 import timeout_decorator
 import logging
-import psycopg2.extras
 import github
+from tests.helpers.utils import local_conn, local_execute
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-@pytest.fixture(scope="session")
-def conn():
-    """psycopg2 connection with auto commit set to True"""
-    conn = psycopg2.connect(connect_timeout=10)
-    conn.set_session(autocommit=True)
-
-    yield conn
-    conn.close()
-
-
-@pytest.fixture(scope="session")
-def cur(conn):
-    """psycopg2 cursor that returns dictionary type results {column_name: value}"""
-    cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
-    yield cur
-    cur.close()
-
-
 @timeout_decorator.timeout(30)
 @pytest.fixture(scope="session")
-def setup_metadb(cur):
+def setup_metadb():
     """Creates `account_dim` and `executions` table"""
     log.info("Creating metadb tables")
+
     with open(
         f"{os.path.dirname(os.path.realpath(__file__))}/../../sql/create_metadb_tables.sql",
         "r",
     ) as f:
-        cur.execute(
-            sql.SQL(f.read().replace("$", "")).format(
-                metadb_schema=sql.Identifier("testing"),
-                metadb_name=sql.Identifier(os.environ["PGDATABASE"]),
+        local_execute(
+            f.read()
+            .replace("$", "")
+            .format(
+                metadb_schema="testing",
+                metadb_name=os.environ["PGDATABASE"],
             )
         )
     yield None
 
     log.info("Dropping metadb tables")
-    cur.execute("DROP TABLE IF EXISTS executions, account_dim")
+    local_execute("DROP TABLE IF EXISTS executions, account_dim")
 
 
 @pytest.fixture(scope="function")
-def truncate_executions(setup_metadb, cur):
+def truncate_executions(setup_metadb):
     """Removes all rows from execution table after every test"""
 
     yield None
 
     log.info("Teardown: Truncating executions table")
-    cur.execute("TRUNCATE executions")
+    local_execute("TRUNCATE executions")
 
 
 @pytest.fixture()
-def mock_conn(mocker, conn):
-    """Patches AWS RDS client with psycopg2 client that connects to the local docker container Postgres database"""
-    return mocker.patch("aurora_data_api.connect", return_value=conn, autospec=True)
+def mock_conn(mocker):
+    """Patches AWS RDS client with a client that connects to the local docker container Postgres database"""
+    return mocker.patch(
+        "aurora_data_api.connect", return_value=local_conn(), autospec=True
+    )
 
 
 @pytest.fixture(scope="function")

--- a/tests/unit/docker/conftest.py
+++ b/tests/unit/docker/conftest.py
@@ -20,7 +20,7 @@ def mock_subprocess_run(cmd: str, check=True):
 
 
 @pytest.fixture(scope="module")
-def account_dim(conn):
+def account_dim():
     """Creates account records within local db"""
     results = insert_records(
         "account_dim",

--- a/tests/unit/docker/conftest.py
+++ b/tests/unit/docker/conftest.py
@@ -4,7 +4,7 @@ import logging
 import git
 import re
 from docker.src.common.utils import subprocess_run
-from tests.helpers.utils import insert_records
+from tests.helpers.utils import insert_records, local_execute
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -20,10 +20,9 @@ def mock_subprocess_run(cmd: str, check=True):
 
 
 @pytest.fixture(scope="module")
-def account_dim(conn, cur):
+def account_dim(conn):
     """Creates account records within local db"""
     results = insert_records(
-        conn,
         "account_dim",
         [
             {
@@ -44,7 +43,7 @@ def account_dim(conn, cur):
 
     yield results
 
-    cur.execute("TRUNCATE account_dim")
+    local_execute("TRUNCATE account_dim")
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/docker/conftest.py
+++ b/tests/unit/docker/conftest.py
@@ -4,7 +4,7 @@ import logging
 import git
 import re
 from docker.src.common.utils import subprocess_run
-from tests.helpers.utils import insert_records, local_execute
+from tests.helpers.utils import insert_records, local_conn
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -43,7 +43,8 @@ def account_dim():
 
     yield results
 
-    local_execute("TRUNCATE account_dim")
+    with local_conn() as conn, conn.cursor() as cur:
+        cur.execute("TRUNCATE account_dim")
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/docker/test_create_deploy_stack.py
+++ b/tests/unit/docker/test_create_deploy_stack.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import uuid
 import git
 import json
-from tests.helpers.utils import dummy_configured_provider_resource
+from tests.helpers.utils import dummy_configured_provider_resource, local_execute
 from tests.unit.docker.conftest import mock_subprocess_run
 from tests.unit.conftest import push
 from docker.src.create_deploy_stack.create_deploy_stack import CreateStack  # noqa: E402
@@ -305,7 +305,7 @@ def test_create_stack(
         )
     ],
 )
-def test_update_executions_with_new_deploy_stack_query(conn, create_stack):
+def test_update_executions_with_new_deploy_stack_query(create_stack):
     """
     Ensures update_executions_with_new_deploy_stack_query() runs the insert
     query without error. Test includes assertion to ensure that the expected
@@ -313,11 +313,9 @@ def test_update_executions_with_new_deploy_stack_query(conn, create_stack):
     """
     with patch.object(task, "create_stack", side_effect=create_stack):
         task.update_executions_with_new_deploy_stack()
-        with conn.cursor() as cur:
-            cur.execute("SELECT COUNT(*) FROM executions")
-            count = cur.fetchone()[0]
+        count = local_execute("SELECT COUNT(*) FROM executions", fetch_one=True)[0]
 
-            assert count == len(create_stack)
+        assert count == len(create_stack)
 
 
 # mock task's env vars

--- a/tests/unit/docker/test_create_deploy_stack.py
+++ b/tests/unit/docker/test_create_deploy_stack.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import uuid
 import git
 import json
-from tests.helpers.utils import dummy_configured_provider_resource, local_execute
+from tests.helpers.utils import dummy_configured_provider_resource, local_conn
 from tests.unit.docker.conftest import mock_subprocess_run
 from tests.unit.conftest import push
 from docker.src.create_deploy_stack.create_deploy_stack import CreateStack  # noqa: E402
@@ -313,7 +313,9 @@ def test_update_executions_with_new_deploy_stack_query(create_stack):
     """
     with patch.object(task, "create_stack", side_effect=create_stack):
         task.update_executions_with_new_deploy_stack()
-        count = local_execute("SELECT COUNT(*) FROM executions", fetch_one=True)[0]
+        with local_conn() as conn, conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM executions")
+            count = cur.fetchone()[0]
 
         assert count == len(create_stack)
 

--- a/tests/unit/functions/approval_response/test_app.py
+++ b/tests/unit/functions/approval_response/test_app.py
@@ -14,7 +14,6 @@ stream = logging.StreamHandler(sys.stdout)
 log.addHandler(stream)
 log.setLevel(logging.DEBUG)
 
-
 voter = "voter-foo"
 task_token = "token-123"
 execution_id = "run-123"
@@ -115,7 +114,7 @@ def test_update_vote(
             """
                 SELECT approval_voters, rejection_voters
                 FROM executions
-                WHERE execution_id = {}
+                WHERE execution_id = '{}'
             """.format(
                 execution_id
             ),

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,0 +1,5 @@
+GitPython
+awscli
+boto3
+aurora-data-api
+request-filter-groups


### PR DESCRIPTION
- Originally aurora-data-api clients were mocked with psycopg2 clients within unit tests. This PR replaces psycopg2 clients with a different aurora-data-api client. The client's associated rds-data boto3 client `endpoint_url` points to a local RDS docker container endpoint. The container acts as a proxy to the metadb container by converting boto3 rds-data requests to SQL queries before sending them to the metadb. The [koxudaxi/local-data-api](https://hub.docker.com/r/koxudaxi/local-data-api) image is used for the proxy container.

- In addition, to reduce the start-up time for running docker commands on the unit test docker service, a custom unit test docker image is used instead of the terrace image. Originally dependencies for the unit test service were installed within the entry point script which lead to the dependencies being installed for every command. With the unit test-specific image, dependencies are cached within the docker image cache.