### PR TITLE
Add local aurora client & replace metadb with aurora client specifc env vars

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 LOCAL_METAB_PORT=8080
-METADB_CLUSTER_ARN=arn:aws:rds:us-east-1:123456789012:cluster:dummy
-METADB_SECRET_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy
+AURORA_CLUSTER_ARN=arn:aws:rds:us-east-1:123456789012:cluster:dummy
+AURORA_SECRET_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy
 METADB_NAME=postgres

--- a/.env
+++ b/.env
@@ -1,4 +1,3 @@
-LOCAL_METAB_PORT=8080
 AURORA_CLUSTER_ARN=arn:aws:rds:us-east-1:123456789012:cluster:dummy
 AURORA_SECRET_ARN=arn:aws:secretsmanager:us-east-1:123456789012:secret:dummy
 METADB_NAME=postgres

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,9 +97,8 @@ jobs:
     - name: Tests
       id: act_pytest_integration
       shell: bash
-      if: ${{ env.ACT }}
       run: |
-        docker compose run integration pytest -vv tests/integration
+        docker compose run --rm integration pytest -vv tests/integration/tasks
 
   e2e:
     needs: [precommit, unit]

--- a/approval.tf
+++ b/approval.tf
@@ -161,8 +161,8 @@ module "lambda_approval_response" {
   timeout = 180
   environment_variables = {
     METADB_NAME                   = local.metadb_name
-    METADB_CLUSTER_ARN            = aws_rds_cluster.metadb.arn
-    METADB_SECRET_ARN             = aws_secretsmanager_secret_version.ci_metadb_user.arn
+    AURORA_CLUSTER_ARN            = aws_rds_cluster.metadb.arn
+    AURORA_SECRET_ARN             = aws_secretsmanager_secret_version.ci_metadb_user.arn
     EMAIL_APPROVAL_SECRET_SSM_KEY = aws_ssm_parameter.email_approval_secret.name
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,9 +85,11 @@ services:
     network_mode: host
     stdin_open: true
     tty: true
-    image: ghcr.io/marshall7m/terrace:v0.1.11
+    image: terraform-aws-infrastructure-live/integration
+    build: ./tests/integration
     volumes:
     - $PWD:/src
+    - /var/run/docker.sock:/var/run/docker.sock
     environment:
     - AWS_ACCESS_KEY_ID=dummy-key
     - AWS_SECRET_ACCESS_KEY=dummy-secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,8 @@ services:
     - POSTGRES_PORT=5432
     - POSTGRES_USER=postgres
     - POSTGRES_PASSWORD=postgres
-    - RESOURCE_ARN=${METADB_CLUSTER_ARN}
-    - SECRET_ARN=${METADB_SECRET_ARN}
+    - RESOURCE_ARN=${AURORA_CLUSTER_ARN}
+    - SECRET_ARN=${AURORA_SECRET_ARN}
     ports:
     - 8080:80
     profiles: [unit, integration]
@@ -58,23 +58,22 @@ services:
     volumes:
     - $PWD:/src
     environment:
-    - AWS_ACCESS_KEY_ID
-    - AWS_SECRET_ACCESS_KEY
-    - AWS_REGION=us-west-2
-    - AWS_DEFAULT_REGION
-    - AWS_SESSION_TOKEN
-    - AWS_SESSION_EXPIRATION
-    - UNTIL_AWS_EXP=30m
+    - AWS_ACCESS_KEY_ID=mock-aws-access-key
+    - AWS_SECRET_ACCESS_KEY=mock-aws-secret-key
+    - AWS_REGION=us-east-1
+    - AWS_DEFAULT_REGION=us-east-1
+    - AWS_SESSION_TOKEN=mock-aws-session-token
+    - AWS_SESSION_EXPIRATION=mock-aws-exp
     - TF_VAR_testing_unit_github_token
     - PGUSER=postgres
     - PGPASSWORD=postgres
     - PGDATABASE=postgres
     - PGHOST=postgres
     - PGPORT=5432
-    - METADB_CLUSTER_ARN=${METADB_CLUSTER_ARN}
+    - AURORA_CLUSTER_ARN=${AURORA_CLUSTER_ARN}
+    - AURORA_SECRET_ARN=${AURORA_SECRET_ARN}
     - METADB_NAME=${METADB_NAME}
-    - METADB_SECRET_ARN=${METADB_SECRET_ARN}
-    - LOCAL_METAB_PORT=${LOCAL_METAB_PORT}
+    - METADB_LOCAL_ENDPOINT=http://127.0.0.1:8080
     entrypoint: [/bin/bash, entrypoint.sh]
     profiles: [unit]
     depends_on:

--- a/docker/src/create_deploy_stack/create_deploy_stack.py
+++ b/docker/src/create_deploy_stack/create_deploy_stack.py
@@ -25,6 +25,9 @@ log.setLevel(logging.DEBUG)
 
 ssm = boto3.client("ssm")
 lb = boto3.client("lambda")
+rds_data_client = boto3.client(
+    "rds-data", endpoint_url=os.environ.get("METAB_LOCAL_ENDPOINT")
+)
 
 
 class CreateStack:
@@ -226,6 +229,7 @@ class CreateStack:
             aurora_cluster_arn=os.environ["METADB_CLUSTER_ARN"],
             secret_arn=os.environ["METADB_SECRET_ARN"],
             database=os.environ["METADB_NAME"],
+            rds_data_client=rds_data_client,
         ) as conn:
             with conn.cursor() as cur:
                 cur.execute(

--- a/docker/src/create_deploy_stack/create_deploy_stack.py
+++ b/docker/src/create_deploy_stack/create_deploy_stack.py
@@ -26,7 +26,7 @@ log.setLevel(logging.DEBUG)
 ssm = boto3.client("ssm")
 lb = boto3.client("lambda")
 rds_data_client = boto3.client(
-    "rds-data", endpoint_url=os.environ.get("METAB_LOCAL_ENDPOINT")
+    "rds-data", endpoint_url=os.environ.get("METADB_LOCAL_ENDPOINT")
 )
 
 
@@ -226,8 +226,8 @@ class CreateStack:
         associated deployment stack within the metadb
         """
         with aurora_data_api.connect(
-            aurora_cluster_arn=os.environ["METADB_CLUSTER_ARN"],
-            secret_arn=os.environ["METADB_SECRET_ARN"],
+            aurora_cluster_arn=os.environ["AURORA_CLUSTER_ARN"],
+            secret_arn=os.environ["AURORA_SECRET_ARN"],
             database=os.environ["METADB_NAME"],
             rds_data_client=rds_data_client,
         ) as conn:

--- a/docker/src/terra_run/run.py
+++ b/docker/src/terra_run/run.py
@@ -59,11 +59,16 @@ def update_new_resources() -> None:
         log.info(f"New Provider Resources:\n{resources}")
 
         if len(resources) > 0:
+            rds_data_client = boto3.client(
+                "rds-data", endpoint_url=os.environ.get("METAB_LOCAL_ENDPOINT")
+            )
+
             log.info("Adding new provider resources to associated execution record")
             with aurora_data_api.connect(
                 aurora_cluster_arn=os.environ["METADB_CLUSTER_ARN"],
                 secret_arn=os.environ["METADB_SECRET_ARN"],
                 database=os.environ["METADB_NAME"],
+                rds_data_client=rds_data_client,
             ) as conn:
                 with conn.cursor() as cur:
                     resources = ",".join(resources)

--- a/docker/src/terra_run/run.py
+++ b/docker/src/terra_run/run.py
@@ -60,13 +60,13 @@ def update_new_resources() -> None:
 
         if len(resources) > 0:
             rds_data_client = boto3.client(
-                "rds-data", endpoint_url=os.environ.get("METAB_LOCAL_ENDPOINT")
+                "rds-data", endpoint_url=os.environ.get("METADB_LOCAL_ENDPOINT")
             )
 
             log.info("Adding new provider resources to associated execution record")
             with aurora_data_api.connect(
-                aurora_cluster_arn=os.environ["METADB_CLUSTER_ARN"],
-                secret_arn=os.environ["METADB_SECRET_ARN"],
+                aurora_cluster_arn=os.environ["AURORA_CLUSTER_ARN"],
+                secret_arn=os.environ["AURORA_SECRET_ARN"],
                 database=os.environ["METADB_NAME"],
                 rds_data_client=rds_data_client,
             ) as conn:

--- a/fargate.tf
+++ b/fargate.tf
@@ -323,11 +323,11 @@ resource "aws_ecs_task_definition" "create_deploy_stack" {
           value = local.metadb_name
         },
         {
-          name  = "METADB_CLUSTER_ARN"
+          name  = "AURORA_CLUSTER_ARN"
           value = aws_rds_cluster.metadb.arn
         },
         {
-          name  = "METADB_SECRET_ARN"
+          name  = "AURORA_SECRET_ARN"
           value = aws_secretsmanager_secret_version.ci_metadb_user.arn
         }
       ])
@@ -424,11 +424,11 @@ resource "aws_ecs_task_definition" "terra_run" {
           value = local.metadb_name
         },
         {
-          name  = "METADB_CLUSTER_ARN"
+          name  = "AURORA_CLUSTER_ARN"
           value = aws_rds_cluster.metadb.arn
         },
         {
-          name  = "METADB_SECRET_ARN"
+          name  = "AURORA_SECRET_ARN"
           value = aws_secretsmanager_secret_version.ci_metadb_user.arn
         },
         {

--- a/functions/approval_response/app.py
+++ b/functions/approval_response/app.py
@@ -30,6 +30,9 @@ class App(object):
         execution = sf.describe_execution(executionArn=execution_arn)
         status = execution["status"]
         execution_id = execution["name"]
+        rds_data_client = boto3.client(
+            "rds-data", endpoint_url=os.environ.get("METAB_LOCAL_ENDPOINT")
+        )
 
         if status == "RUNNING":
             log.info("Updating vote count")
@@ -40,6 +43,7 @@ class App(object):
                 aurora_cluster_arn=os.environ["METADB_CLUSTER_ARN"],
                 secret_arn=os.environ["METADB_SECRET_ARN"],
                 database=os.environ["METADB_NAME"],
+                rds_data_client=rds_data_client,
             ) as conn:
                 with conn.cursor() as cur:
                     with open(

--- a/functions/approval_response/app.py
+++ b/functions/approval_response/app.py
@@ -20,28 +20,31 @@ from common_lambda.utils import (
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+sf = boto3.client("stepfunctions")
+rds_data_client = boto3.client(
+    "rds-data", endpoint_url=os.environ.get("METADB_LOCAL_ENDPOINT")
+)
+ssm = boto3.client("ssm")
+
 
 class App(object):
     def __init__(self):
         self.listeners = {}
 
     def update_vote(self, execution_arn: str, action: str, voter: str, task_token: str):
-        sf = boto3.client("stepfunctions")
         execution = sf.describe_execution(executionArn=execution_arn)
         status = execution["status"]
         execution_id = execution["name"]
-        rds_data_client = boto3.client(
-            "rds-data", endpoint_url=os.environ.get("METAB_LOCAL_ENDPOINT")
-        )
 
         if status == "RUNNING":
             log.info("Updating vote count")
             # NOTE: If query execution time is too long and
             #  causes downstream timeouts, invoke async lambda with
             #  query and return submission response from this function
+            log.debug(pformat(os.environ))
             with aurora_data_api.connect(
-                aurora_cluster_arn=os.environ["METADB_CLUSTER_ARN"],
-                secret_arn=os.environ["METADB_SECRET_ARN"],
+                aurora_cluster_arn=os.environ["AURORA_CLUSTER_ARN"],
+                secret_arn=os.environ["AURORA_SECRET_ARN"],
                 database=os.environ["METADB_NAME"],
                 rds_data_client=rds_data_client,
             ) as conn:
@@ -114,8 +117,6 @@ class App(object):
                 )
             except ValidationError as e:
                 return aws_response(status_code=422, response=str(e))
-
-            ssm = boto3.client("ssm")
 
             secret = ssm.get_parameter(
                 Name=os.environ["EMAIL_APPROVAL_SECRET_SSM_KEY"], WithDecryption=True

--- a/functions/trigger_sf/lambda_function.py
+++ b/functions/trigger_sf/lambda_function.py
@@ -17,6 +17,9 @@ log.setLevel(logging.DEBUG)
 
 sf = boto3.client("stepfunctions")
 ssm = boto3.client("ssm")
+rds_data_client = boto3.client(
+    "rds-data", endpoint_url=os.environ.get("METAB_LOCAL_ENDPOINT")
+)
 
 
 def _execution_finished(cur, execution: map, account_id) -> None:
@@ -215,6 +218,7 @@ def lambda_handler(event, context):
             aurora_cluster_arn=os.environ["METADB_CLUSTER_ARN"],
             secret_arn=os.environ["METADB_SECRET_ARN"],
             database=os.environ["METADB_NAME"],
+            rds_data_client=rds_data_client,
         ) as conn:
             with conn.cursor() as cur:
                 if "execution" in event:

--- a/functions/trigger_sf/lambda_function.py
+++ b/functions/trigger_sf/lambda_function.py
@@ -18,7 +18,7 @@ log.setLevel(logging.DEBUG)
 sf = boto3.client("stepfunctions")
 ssm = boto3.client("ssm")
 rds_data_client = boto3.client(
-    "rds-data", endpoint_url=os.environ.get("METAB_LOCAL_ENDPOINT")
+    "rds-data", endpoint_url=os.environ.get("METADB_LOCAL_ENDPOINT")
 )
 
 
@@ -215,8 +215,8 @@ def lambda_handler(event, context):
     log.debug(f"Event:\n{event}")
     try:
         with aurora_data_api.connect(
-            aurora_cluster_arn=os.environ["METADB_CLUSTER_ARN"],
-            secret_arn=os.environ["METADB_SECRET_ARN"],
+            aurora_cluster_arn=os.environ["AURORA_CLUSTER_ARN"],
+            secret_arn=os.environ["AURORA_SECRET_ARN"],
             database=os.environ["METADB_NAME"],
             rds_data_client=rds_data_client,
         ) as conn:

--- a/main.tf
+++ b/main.tf
@@ -166,11 +166,11 @@ resource "aws_sfn_state_machine" "this" {
                         "Value" = local.metadb_name
                       },
                       {
-                        "Name"  = "METADB_CLUSTER_ARN"
+                        "Name"  = "AURORA_CLUSTER_ARN"
                         "Value" = aws_rds_cluster.metadb.arn
                       },
                       {
-                        "Name"  = "METADB_SECRET_ARN"
+                        "Name"  = "AURORA_SECRET_ARN"
                         "Value" = aws_secretsmanager_secret_version.ci_metadb_user.arn
                       },
                       {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@ import os
 import datetime
 import re
 import logging
+import timeout_decorator
+from tests.helpers.utils import rds_data_client
+import aurora_data_api
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -77,3 +80,46 @@ def aws_session_expiration_check(request):
             log.info("$AWS_SESSION_EXPIRATION is not set -- skipping check")
     else:
         log.info("Neither --until-aws-exp nor $UNTIL_AWS_EXP was set -- skipping check")
+
+
+@timeout_decorator.timeout(30)
+@pytest.fixture(scope="session")
+def setup_metadb():
+    """Creates `account_dim` and `executions` table"""
+    log.info("Creating metadb tables")
+
+    with aurora_data_api.connect(
+        database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+    ) as conn, conn.cursor() as cur:
+        with open(
+            f"{os.path.dirname(os.path.realpath(__file__))}/../../sql/create_metadb_tables.sql",
+            "r",
+        ) as f:
+            cur.execute(
+                f.read()
+                .replace("$", "")
+                .format(
+                    metadb_schema="testing",
+                    metadb_name=os.environ["PGDATABASE"],
+                )
+            )
+    yield None
+
+    log.info("Dropping metadb tables")
+    with aurora_data_api.connect(
+        database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+    ) as conn, conn.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS executions, account_dim")
+
+
+@pytest.fixture(scope="function")
+def truncate_executions(setup_metadb):
+    """Removes all rows from execution table after every test"""
+
+    yield None
+
+    log.info("Teardown: Truncating executions table")
+    with aurora_data_api.connect(
+        database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+    ) as conn, conn.cursor() as cur:
+        cur.execute("TRUNCATE executions")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,12 +87,11 @@ def aws_session_expiration_check(request):
 def setup_metadb():
     """Creates `account_dim` and `executions` table"""
     log.info("Creating metadb tables")
-
     with aurora_data_api.connect(
         database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
     ) as conn, conn.cursor() as cur:
         with open(
-            f"{os.path.dirname(os.path.realpath(__file__))}/../../sql/create_metadb_tables.sql",
+            f"{os.path.dirname(os.path.realpath(__file__))}/../sql/create_metadb_tables.sql",
             "r",
         ) as f:
             cur.execute(

--- a/tests/integration/step-function/skeleton_sf_def.tf
+++ b/tests/integration/step-function/skeleton_sf_def.tf
@@ -136,11 +136,11 @@ locals {
                     "Value" = local.metadb_name
                   },
                   {
-                    "Name"  = "METADB_CLUSTER_ARN"
+                    "Name"  = "AURORA_CLUSTER_ARN"
                     "Value" = aws_rds_cluster.metadb.arn
                   },
                   {
-                    "Name"  = "METADB_SECRET_ARN"
+                    "Name"  = "AURORA_SECRET_ARN"
                     "Value" = aws_secretsmanager_secret_version.ci_metadb_user.arn
                   },
                   {

--- a/tests/unit/docker/conftest.py
+++ b/tests/unit/docker/conftest.py
@@ -4,7 +4,8 @@ import logging
 import git
 import re
 from docker.src.common.utils import subprocess_run
-from tests.helpers.utils import insert_records, local_conn
+from tests.helpers.utils import insert_records, rds_data_client
+import aurora_data_api
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -43,7 +44,9 @@ def account_dim():
 
     yield results
 
-    with local_conn() as conn, conn.cursor() as cur:
+    with aurora_data_api.connect(
+        database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+    ) as conn, conn.cursor() as cur:
         cur.execute("TRUNCATE account_dim")
 
 

--- a/tests/unit/docker/test_create_deploy_stack.py
+++ b/tests/unit/docker/test_create_deploy_stack.py
@@ -285,9 +285,6 @@ def test_create_stack(
 @patch.dict(
     os.environ,
     {
-        "METADB_CLUSTER_ARN": "mock",
-        "METADB_SECRET_ARN": "mock",
-        "METADB_NAME": "mock",
         "PR_ID": "1",
         "COMMIT_ID": "commit-1",
         "BASE_REF": "master",
@@ -329,9 +326,6 @@ def test_update_executions_with_new_deploy_stack_query(create_stack):
     {
         "BASE_REF": "master",
         "HEAD_REF": "test-feature",
-        "METADB_CLUSTER_ARN": "mock",
-        "METADB_SECRET_ARN": "mock",
-        "METADB_NAME": "mock",
         "STATE_MACHINE_ARN": "mock",
         "GITHUB_MERGE_LOCK_SSM_KEY": "mock-ssm-key",
         "TRIGGER_SF_FUNCTION_NAME": "mock-lambda",

--- a/tests/unit/docker/test_terra_run.py
+++ b/tests/unit/docker/test_terra_run.py
@@ -4,8 +4,9 @@ import os
 import logging
 from subprocess import CalledProcessError
 import json
+import aurora_data_api
 from unittest.mock import patch, call
-from tests.helpers.utils import null_provider_resource, insert_records, local_conn
+from tests.helpers.utils import null_provider_resource, insert_records, rds_data_client
 from docker.src.terra_run.run import (
     update_new_resources,
     get_new_provider_resources,
@@ -88,7 +89,7 @@ def test_get_new_provider_resources(mock_run, repo_changes, new_providers, expec
     },
 )
 @patch("docker.src.terra_run.run.get_new_provider_resources")
-@pytest.mark.usefixtures("mock_conn", "aws_credentials", "truncate_executions")
+@pytest.mark.usefixtures("aws_credentials", "truncate_executions")
 @pytest.mark.parametrize(
     "resources",
     [
@@ -110,7 +111,9 @@ def test_update_new_resources(mock_get_new_provider_resources, resources):
 
     update_new_resources()
 
-    with local_conn() as conn, conn.cursor() as cur:
+    with aurora_data_api.connect(
+        database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+    ) as conn, conn.cursor() as cur:
         cur.execute(
             f"""
             SELECT new_resources

--- a/tests/unit/docker/test_terra_run.py
+++ b/tests/unit/docker/test_terra_run.py
@@ -76,9 +76,6 @@ def test_get_new_provider_resources(mock_run, repo_changes, new_providers, expec
 @patch.dict(
     os.environ,
     {
-        "METADB_CLUSTER_ARN": "mock",
-        "METADB_SECRET_ARN": "mock",
-        "METADB_NAME": "mock",
         "TG_BACKEND": "local",
         "EXECUTION_ID": "test-id",
         "TG_COMMAND": "",

--- a/tests/unit/functions/approval_response/test_app.py
+++ b/tests/unit/functions/approval_response/test_app.py
@@ -78,18 +78,17 @@ execution_id = "run-123"
         ),
     ],
 )
-@pytest.mark.usefixtures("aws_credentials", "truncate_executions")
-@patch("boto3.client")
+@pytest.mark.usefixtures("truncate_executions")
+@patch("app.sf")
 def test_update_vote(
-    mock_boto_client,
+    mock_sf,
     action,
     status,
     record,
     expectation,
     expect_send_task_token,
 ):
-    mock_boto_client.return_value = mock_boto_client
-    mock_boto_client.describe_execution.return_value = {
+    mock_sf.describe_execution.return_value = {
         "status": status,
         "name": "run-123",
     }
@@ -130,7 +129,7 @@ def test_update_vote(
             assert voter not in res["approval_voters"]
 
     if expect_send_task_token:
-        mock_boto_client.send_task_success.assert_called_with(
+        mock_sf.send_task_success.assert_called_with(
             taskToken=task_token,
             output=json.dumps(action),
         )

--- a/tests/unit/functions/approval_response/test_app.py
+++ b/tests/unit/functions/approval_response/test_app.py
@@ -78,10 +78,6 @@ execution_id = "run-123"
         ),
     ],
 )
-@patch.dict(
-    os.environ,
-    {"METADB_CLUSTER_ARN": "mock", "METADB_SECRET_ARN": "mock", "METADB_NAME": "mock"},
-)
 @pytest.mark.usefixtures("aws_credentials", "truncate_executions")
 @patch("boto3.client")
 def test_update_vote(

--- a/tests/unit/functions/approval_response/test_ses.py
+++ b/tests/unit/functions/approval_response/test_ses.py
@@ -54,13 +54,13 @@ event = {
     ],
 )
 @patch.dict(os.environ, {"EMAIL_APPROVAL_SECRET_SSM_KEY": "mock-key"})
-@patch("boto3.client")
+@patch("app.ssm")
 @patch.object(app, "update_vote")
 @patch("hmac.compare_digest")
 def test_ses_approve(
     mock_compare_digest,
     mock_update_vote,
-    mock_boto_client,
+    mock_ssm,
     event,
     update_vote_side_effect,
     authorized_request,
@@ -68,11 +68,7 @@ def test_ses_approve(
 ):
     mock_compare_digest.return_value = authorized_request
     mock_update_vote.side_effect = update_vote_side_effect
-    mock_boto_client.return_value = mock_boto_client
-    mock_boto_client.get_parameter.return_value = {
-        "Parameter": {"Value": "mock-secret"}
-    }
-
+    mock_ssm.get_parameter.return_value = {"Parameter": {"Value": "mock-secret"}}
     handler = ApprovalHandler(app=app)
 
     response = handler.handle(event, {})

--- a/tests/unit/functions/test_approval_request.py
+++ b/tests/unit/functions/test_approval_request.py
@@ -55,7 +55,6 @@ event = {
         ),
     ],
 )
-@pytest.mark.usefixtures("mock_conn")
 @patch.dict(
     os.environ,
     {"SES_TEMPLATE": "mock-template", "SENDER_EMAIL_ADDRESS": "user@invalid.com"},

--- a/tests/unit/functions/test_trigger_sf.py
+++ b/tests/unit/functions/test_trigger_sf.py
@@ -3,7 +3,8 @@ from unittest.mock import patch
 import os
 import json
 import logging
-from tests.helpers.utils import insert_records, local_conn
+import aurora_data_api
+from tests.helpers.utils import insert_records, rds_data_client
 from functions.trigger_sf import lambda_function
 
 log = logging.getLogger(__name__)
@@ -136,7 +137,9 @@ def test__execution_finished_status_update(
         "Parameter": {"Value": json.dumps({"Execution": True})}
     }
 
-    with local_conn() as conn, conn.cursor() as cur:
+    with aurora_data_api.connect(
+        database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+    ) as conn, conn.cursor() as cur:
         mock_sf.list_executions.return_value = {
             "executions": [
                 {"name": record["execution_id"], "executionArn": "mock-arn"}
@@ -212,7 +215,7 @@ def test__execution_finished_status_update(
         "GITHUB_MERGE_LOCK_SSM_KEY": "mock-ssm-key",
     },
 )
-@pytest.mark.usefixtures("mock_conn", "aws_credentials", "truncate_executions")
+@pytest.mark.usefixtures("aws_credentials", "truncate_executions")
 @pytest.mark.parametrize(
     "records,expected_running_ids",
     [
@@ -357,11 +360,15 @@ def test__start_executions(mock_sf, records, expected_running_ids):
 
     records = insert_records("executions", records, enable_defaults=True)
 
-    with local_conn() as conn, conn.cursor() as cur:
+    with aurora_data_api.connect(
+        database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+    ) as conn, conn.cursor() as cur:
         lambda_function._start_sf_executions(cur)
 
     log.info("Assert started Step Function execution statuses were updated to running")
-    with local_conn() as conn, conn.cursor() as cur:
+    with aurora_data_api.connect(
+        database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+    ) as conn, conn.cursor() as cur:
         cur.execute("SELECT execution_id FROM executions WHERE status = 'running'")
         res = cur.fetchall()
     res = [record[0] for record in res]
@@ -388,7 +395,7 @@ def test__start_executions(mock_sf, records, expected_running_ids):
     ],
 )
 @patch("functions.trigger_sf.lambda_function.ssm")
-@pytest.mark.usefixtures("mock_conn", "aws_credentials", "truncate_executions")
+@pytest.mark.usefixtures("aws_credentials", "truncate_executions")
 @patch.dict(
     os.environ,
     {

--- a/tests/unit/functions/test_trigger_sf.py
+++ b/tests/unit/functions/test_trigger_sf.py
@@ -208,9 +208,6 @@ def test__execution_finished_status_update(
     os.environ,
     {
         "COMMIT_STATUS_CONFIG_SSM_KEY": "mock-ssm-config-key",
-        "METADB_CLUSTER_ARN": "mock",
-        "METADB_SECRET_ARN": "mock",
-        "METADB_NAME": "mock",
         "STATE_MACHINE_ARN": "mock",
         "GITHUB_MERGE_LOCK_SSM_KEY": "mock-ssm-key",
     },
@@ -400,9 +397,6 @@ def test__start_executions(mock_sf, records, expected_running_ids):
     os.environ,
     {
         "COMMIT_STATUS_CONFIG_SSM_KEY": "mock-ssm-config-key",
-        "METADB_CLUSTER_ARN": "mock",
-        "METADB_SECRET_ARN": "mock",
-        "METADB_NAME": "mock",
         "STATE_MACHINE_ARN": "mock",
         "GITHUB_MERGE_LOCK_SSM_KEY": "mock-ssm-key",
     },

--- a/trigger_sf.tf
+++ b/trigger_sf.tf
@@ -54,8 +54,8 @@ module "lambda_trigger_sf" {
     PGUSER             = var.metadb_ci_username
     PGPORT             = var.metadb_port
     METADB_NAME        = local.metadb_name
-    METADB_CLUSTER_ARN = aws_rds_cluster.metadb.arn
-    METADB_SECRET_ARN  = aws_secretsmanager_secret_version.ci_metadb_user.arn
+    AURORA_CLUSTER_ARN = aws_rds_cluster.metadb.arn
+    AURORA_SECRET_ARN  = aws_secretsmanager_secret_version.ci_metadb_user.arn
   }
 
   allowed_triggers = {


### PR DESCRIPTION
Given that future integration tests will use the local proxy RDS container endpoint for metadb queries, the local ECS tasks need a way to point the rds-data request to the proxy container. One solution is to add the pytest dependencies and tests within the ECS tasks using a multi-stage build and then mocking the remote RDS clients with the local RDS client. The downside of this is that the ECS task docker image used in the integration tests will not reflect the image used in production.  

The approach within this PR adds a `METADB_LOCAL_ENDPOINT` env var to the rds-data client used within the Lambda Functions and ECS tasks. In a remote environment, the `METADB_LOCAL_ENDPOINT` will not be set resulting in the remote endpoint URL being used while in a local testing environment, the `METADB_LOCAL_ENDPOINT` will be set to the local rds-data container endpoint.

In addition, the `METAB_CLUSTER_ARN` and `METADB_SECRET_ARN` env vars are replaced with  `AURORA_CLUSTER_ARN` and `AURORA_SECRET_ARN`.  This takes advantage of the fact that `AURORA_*` env vars are used by default within the aurora-data-api client. This will reduce the number of times the cluster and secret ARN are set within the aurora-data-api client. Given that there are no other RDS clusters being referenced within the scope of this Terraform module, there is no need to distinguish cluster and secret ARNs via distinct env vars.