### PR TITLE
Move core logic away from trigger sf lamba_handler()

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
       * [Features:](#features)
       * [Improvements:](#improvements)
 
-<!-- Added by: root, at: Thu Sep 22 16:20:17 UTC 2022 -->
+<!-- Added by: root, at: Thu Oct 13 00:10:02 UTC 2022 -->
 
 <!--te-->
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@
       * [Features:](#features)
       * [Improvements:](#improvements)
 
+<!-- Added by: root, at: Thu Oct 13 15:58:28 UTC 2022 -->
 
-<!-- Added by: root, at: Wed Oct 12 18:13:49 UTC 2022 -->
 <!--te-->
 
 

--- a/functions/trigger_sf/lambda_function.py
+++ b/functions/trigger_sf/lambda_function.py
@@ -2,9 +2,10 @@ import os
 import sys
 import logging
 import json
+from typing import List
+
 import boto3
 import aurora_data_api
-from pprint import pformat
 import github
 
 sys.path.append(os.path.dirname(__file__) + "/..")
@@ -22,242 +23,294 @@ rds_data_client = boto3.client(
 )
 
 
-def _execution_finished(cur, execution: map, account_id) -> None:
-    """
-    Updates the Step Function's associated metadb record status and handles
-    the case where the Step Function execution fails or is aborted
+class ExecutionFinished:
+    def __init__(
+        self,
+        execution_id: str,
+        status: str,
+        is_rollback: bool,
+        commit_id: str,
+        cfg_path: str,
+    ):
+        """
+        Handles AWS EventBridge rule event that's triggered by finished Step
+        Function executions
 
-    Arguments:
-        execution: Cloudwatch event payload associated with finished Step
-            Function execution
-        account_id: AWS account ID that the Step Function machine is hosted in
-    """
+        Arguments:
+            status: Step Funciton execution event data from EventBridge rule
+            account_id: AWS account ID of the Step Function machine
+        """
+        self.execution_id = execution_id
+        self.status = status
+        self.is_rollback = is_rollback
+        self.commit_id = commit_id
+        self.cfg_path = cfg_path
 
-    log.info("Updating execution record status")
-    cur.execute(
-        f"""
-    UPDATE executions
-    SET "status" = '{execution['status']}'
-    WHERE execution_id = '{execution['execution_id']}'
-    """
-    )
+    def update_status(self) -> None:
+        """Updates finished Step Function execution's associated metadb record status"""
+        with aurora_data_api.connect(
+            database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+        ) as conn, conn.cursor() as cur:
+            log.info("Updating execution record status")
+            cur.execute(
+                f"""
+            UPDATE executions
+            SET "status" = '{self.status}'
+            WHERE execution_id = '{self.execution_id}'
+            """
+            )
 
-    commit_status_config = json.loads(
-        ssm.get_parameter(Name=os.environ["COMMIT_STATUS_CONFIG_SSM_KEY"])["Parameter"][
-            "Value"
-        ]
-    )
-
-    log.debug(f"Commit status config:\n{pformat(commit_status_config)}")
-
-    if commit_status_config["Execution"]:
-        log.info("Sending commit status")
-
+    def send_commit_status(self) -> None:
+        """Sends a GitHub commit status to the execution's associated commit"""
         token = ssm.get_parameter(
             Name=os.environ["GITHUB_TOKEN_SSM_KEY"], WithDecryption=True
         )["Parameter"]["Value"]
 
-        if execution["status"] in ["failed", "aborted"]:
+        if self.status in ["failed", "aborted"]:
             state = "failure"
         else:
             state = "success"
 
         gh = github.Github(token)
         gh.get_repo(os.environ["REPO_FULL_NAME"]).get_commit(
-            execution["commit_id"]
+            self.commit_id
         ).create_status(
             state=state,
             description="Step Function Execution",
-            context=execution["execution_id"],
-            target_url=f"https://{os.environ['AWS_REGION']}.console.aws.amazon.com/states/home?region={os.environ['AWS_REGION']}#/executions/details/arn:aws:states:{os.environ['AWS_REGION']}:{account_id}:execution:{os.environ['STATE_MACHINE_ARN'].split(':')[-1]}:{execution['execution_id']}",
+            context=self.execution_id,
+            target_url=f"https://{os.environ['AWS_REGION']}.console.aws.amazon.com/states/home?region={os.environ['AWS_REGION']}#/executions/details/arn:aws:states:{os.environ['AWS_REGION']}:{self.account_id}:execution:{os.environ['STATE_MACHINE_ARN'].split(':')[-1]}:{self.execution_id}",
         )
 
-    if not execution["is_rollback"] and execution["status"] in ["failed", "aborted"]:
-        log.info("Aborting all deployments for commit")
-        cur.execute(
-            f"""
-        UPDATE executions
-        SET "status" = 'aborted'
-        WHERE "status" IN ('waiting', 'running')
-        AND commit_id = '{execution['commit_id']}'
-        AND is_rollback = false
-        RETURNING execution_id
-        """
-        )
+    def create_rollback_records(self) -> None:
+        with aurora_data_api.connect(
+            database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+        ) as conn, conn.cursor() as cur:
+            with open(
+                f"{os.path.dirname(os.path.realpath(__file__))}/sql/update_executions_with_new_rollback_stack.sql",
+                "r",
+            ) as f:
+                cur.execute(f.read().format(commit_id=self.commit_id))
+                results = cur.fetchall()
+                log.debug(f"Results:\n{results}")
+                if len(results) != 0:
+                    rollback_records = [
+                        dict(zip([desc.name for desc in cur.description], record))
+                        for record in results
+                    ]
+                    log.debug(f"Rollback records:\n{rollback_records}")
 
-        results = cur.fetchall()
+    def abort_sf_executions(self, ids):
+        sf = boto3.client("stepfunctions")
+        log.info("Aborting Step Function executions")
+        for _id in ids:
+            log.debug(f"Execution ID: {_id}")
+            try:
+                print(sf)
+                execution_arn = [
+                    execution["executionArn"]
+                    for execution in sf.list_executions(
+                        stateMachineArn=os.environ["STATE_MACHINE_ARN"]
+                    )["executions"]
+                    if execution["name"] == _id
+                ][0]
+            except IndexError:
+                log.debug(
+                    f"Step Function execution for execution ID does not exist: {_id}"
+                )
+                continue
+            log.debug(f"Execution ARN: {execution_arn}")
+
+            sf.stop_execution(
+                executionArn=execution_arn,
+                error="DependencyError",
+                cause=f"cfg_path dependency failed: {self.cfg_path}",
+            )
+
+    def abort_commit_records(self) -> List[str]:
+        with aurora_data_api.connect(
+            database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+        ) as conn, conn.cursor() as cur:
+            cur.execute(
+                f"""
+            UPDATE executions
+            SET "status" = 'aborted'
+            WHERE "status" IN ('waiting', 'running')
+            AND commit_id = '{self.commit_id}'
+            AND is_rollback = false
+            RETURNING execution_id
+            """
+            )
+
+            results = cur.fetchall()
+
         log.debug(f"Results: {results}")
-        if len(results) != 0:
-            aborted_ids = [r[0] for r in results]
+        return [r[0] for r in results if r[0] is not None]
 
-            log.info("Aborting Step Function executions")
-            for id in aborted_ids:
-                log.debug(f"Execution ID: {id}")
-                try:
-                    execution_arn = [
-                        execution["executionArn"]
-                        for execution in sf.list_executions(
-                            stateMachineArn=os.environ["STATE_MACHINE_ARN"]
-                        )["executions"]
-                        if execution["name"] == id
-                    ][0]
-                except IndexError:
-                    log.debug(
-                        f"Step Function execution for execution ID does not exist: {id}"
-                    )
-                    continue
-                log.debug(f"Execution ARN: {execution_arn}")
+    def handle_failed_execution(self) -> None:
+        """
+        Updates the Step Function's associated metadb record status and handles
+        the case where the Step Function execution fails or is aborted
+        """
+        if self.status in ["failed", "aborted"]:
+            if not self.is_rollback:
+                log.info("Aborting all deployments for commit")
+                aborted_ids = self.abort_commit_records()
 
-                sf.stop_execution(
-                    executionArn=execution_arn,
-                    error="DependencyError",
-                    cause=f'cfg_path dependency failed: {execution["cfg_path"]}',
+                self.abort_sf_executions(aborted_ids)
+
+                log.info("Creating rollback executions if needed")
+                self.create_rollback_records()
+
+            elif self.is_rollback:
+                # not aborting waiting and running rollback executions to allow CI flow
+                # to continue after admin intervention since future PR deployments
+                # will break if the new provider resources are not destroyed beforehand
+                raise ClientException(
+                    "Rollback execution failed -- User with administrative privileges will need to manually fix configuration"
                 )
 
-        log.info("Creating rollback executions if needed")
-        with open(
-            f"{os.path.dirname(os.path.realpath(__file__))}/sql/update_executions_with_new_rollback_stack.sql",
-            "r",
-        ) as f:
-            cur.execute(f.read().format(commit_id=execution["commit_id"]))
-            results = cur.fetchall()
-            log.debug(f"Results:\n{results}")
-            if len(results) != 0:
-                rollback_records = [
-                    dict(zip([desc.name for desc in cur.description], record))
-                    for record in results
-                ]
-                log.debug(f"Rollback records:\n{rollback_records}")
 
-    elif execution["is_rollback"] is True and execution["status"] in [
-        "failed",
-        "aborted",
-    ]:
-        # not aborting waiting and running rollback executions to allow CI flow
-        # to continue after admin intervention since future PR deployments
-        # will break if the new provider resources are not destroyed beforehand
-        raise ClientException(
-            "Rollback execution failed -- User with administrative privileges will need to manually fix configuration"
-        )
-
-
-def _start_sf_executions(cur) -> None:
+def check_executions_running() -> bool:
     """
-    Selects execution records to pass to Step Function deployment flow and
-    starts the Step Function executions
-
-    Arguments:
-        cur: Database cursor
+    Returns True if any execution records have a status of waiting or running
+    and False otherwise
     """
+    with aurora_data_api.connect(
+        database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+    ) as conn, conn.cursor() as cur:
+        log.info("Checking if commit executions are in progress")
+        cur.execute("SELECT 1 FROM executions WHERE status IN ('waiting', 'running')")
 
-    log.info(
-        "Getting executions that have all account dependencies and terragrunt dependencies met"
-    )
+        if cur.rowcount > 0:
+            return True
+
+        return False
+
+
+def get_target_execution_ids() -> List[str]:
+    """
+    Returns list of execution IDs that have all account dependencies and
+    terragrunt dependencies met
+    """
     try:
-        with open(
-            f"{os.path.dirname(os.path.realpath(__file__))}/sql/select_target_execution_ids.sql"
-        ) as f:
-            cur.execute(f.read())
-            cur.execute("SELECT get_target_execution_ids()")
+        with aurora_data_api.connect(
+            database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+        ) as conn, conn.cursor() as cur:
+            with open(
+                f"{os.path.dirname(os.path.realpath(__file__))}/sql/select_target_execution_ids.sql"
+            ) as f:
+                cur.execute(f.read())
+                cur.execute("SELECT get_target_execution_ids()")
+                results = cur.fetchone()
+
     except aurora_data_api.exceptions.DatabaseError as e:
         log.error(e, exc_info=True)
         log.error(
             f'Merge lock value: {ssm.get_parameter(Name=os.environ["GITHUB_MERGE_LOCK_SSM_KEY"])["Parameter"]["Value"]}'
         )
-        sys.exit(1)
-
-    results = cur.fetchone()
-    log.debug(f"Results: {results}")
+        raise e
 
     if results[0] is None:
+        return []
+
+    return results[0]
+
+
+def start_sf_executions() -> None:
+    ids = get_target_execution_ids()
+    log.debug(f"IDs: {ids}")
+    log.debug(f"Count: {len(ids)}")
+
+    if len(ids) == 0:
         log.info("No executions are ready")
         return
-    else:
-        ids = results[0]
-
-    log.debug(f"IDs: {ids}")
-    log.info(f"Count: {len(ids)}")
 
     if "DRY_RUN" in os.environ:
         log.info("DRY_RUN was set -- skip starting sf executions")
     else:
-        # TODO: replace built-in `id` var (use id_ ?)
-        for id in ids:
-            log.info(f"Execution ID: {id}")
+        with aurora_data_api.connect(
+            database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+        ) as conn, conn.cursor() as cur:
+            for _id in ids:
+                log.info(f"Execution ID: {_id}")
 
-            log.debug("Updating execution status to running")
-            cur.execute(
-                f"""
-                UPDATE executions
-                SET status = 'running'
-                WHERE execution_id = '{id}'
-                RETURNING *
-            """
-            )
+                log.debug("Updating execution status to running")
+                cur.execute(
+                    f"""
+                    UPDATE executions
+                    SET status = 'running'
+                    WHERE execution_id = '{_id}'
+                    RETURNING *
+                """
+                )
 
-            sf_input = json.dumps(
-                dict(zip([desc.name for desc in cur.description], cur.fetchone()))
-            )
-            log.debug(f"SF input:\n{sf_input}")
+                sf_input = json.dumps(
+                    dict(zip([desc.name for desc in cur.description], cur.fetchone()))
+                )
+                log.debug(f"SF input:\n{sf_input}")
 
-            log.info("Starting sf execution")
-            sf.start_execution(
-                stateMachineArn=os.environ["STATE_MACHINE_ARN"], name=id, input=sf_input
-            )
+                log.info("Starting sf execution")
+                sf.start_execution(
+                    stateMachineArn=os.environ["STATE_MACHINE_ARN"],
+                    name=_id,
+                    input=sf_input,
+                )
 
 
 def lambda_handler(event, context):
     """
-    Runs Step Function deployment flow or resets SSM Parameter Store merge
-    lock value if deployment stack is empty
+    Updates finished Step Function execution status if Lambda Function was triggered by EventBridge.
+    Otherwise runs the Step Function deployment flow or resets the SSM Parameter Store merge
+    lock value if deployment stack is empty.
     """
-
     log.debug(f"Event:\n{event}")
     try:
-        with aurora_data_api.connect(
-            aurora_cluster_arn=os.environ["AURORA_CLUSTER_ARN"],
-            secret_arn=os.environ["AURORA_SECRET_ARN"],
-            database=os.environ["METADB_NAME"],
-            rds_data_client=rds_data_client,
-        ) as conn:
-            with conn.cursor() as cur:
-                if "execution" in event:
-                    execution = event["execution"]
-                    log.info(
-                        f'Triggered via Step Function Event:\n{event["execution"]}'
-                    )
-                    if execution["output"] is None:
-                        # use step function execution input since the output is none when execution is aborted
-                        record = {
-                            **json.loads(execution["input"]),
-                            **{"status": execution["status"].lower()},
-                        }
-                    else:
-                        record = json.loads(execution["output"])
-                    _execution_finished(
-                        cur, record, context.invoked_function_arn.split(":")[4]
-                    )
+        if event.get("execution"):
+            output = event["execution"].get("output")
+            if output:
+                execution = json.loads(output)
+            else:
+                # use step function execution input since the output is none when execution is aborted
+                execution = {
+                    **json.loads(event["execution"]["input"]),
+                    **{"status": event["execution"]["status"].lower()},
+                }
 
-                log.info("Checking if commit executions are in progress")
-                cur.execute(
-                    "SELECT 1 FROM executions WHERE status IN ('waiting', 'running')"
-                )
+            log.info(f"Triggered via Step Function Event:\n{execution}")
 
-                if cur.rowcount > 0:
-                    log.info("Starting Step Function Deployment Flow")
-                    _start_sf_executions(cur)
-                else:
-                    log.info(
-                        "No executions are waiting or running -- unlocking merge action within target branch"
-                    )
-                    ssm.put_parameter(
-                        Name=os.environ["GITHUB_MERGE_LOCK_SSM_KEY"],
-                        Value="none",
-                        Type="String",
-                        Overwrite=True,
-                    )
+            send_commit_status = json.loads(
+                ssm.get_parameter(Name=os.environ["COMMIT_STATUS_CONFIG_SSM_KEY"])[
+                    "Parameter"
+                ]["Value"]
+            ).get("Execution")
 
-                return {"statusCode": 200, "message": "Invocation was successful"}
+            execution = ExecutionFinished(
+                status=execution["status"],
+                is_rollback=execution["is_rollback"],
+                commit_id=execution["commit_id"],
+                cfg_path=execution["cfg_path"],
+                account_id=context.invoked_function_arn.split(":")[4],
+            )
+
+            execution.update_status()
+            execution.send_commit_status(send_commit_status)
+            execution.handle_failed_execution()
+
+        running = check_executions_running()
+
+        if running:
+            log.info("Starting Step Function Deployment Flow")
+            start_sf_executions()
+        else:
+            log.info("Unlocking merge action within target branch")
+            ssm.put_parameter(
+                Name=os.environ["GITHUB_MERGE_LOCK_SSM_KEY"],
+                Value="none",
+                Type="String",
+                Overwrite=True,
+            )
+
+        return {"statusCode": 200, "message": "Invocation was successful"}
     except Exception as e:
         log.error(e, exc_info=True)
         return {"statusCode": 500, "message": "Invocation was unsuccessful"}

--- a/tests/unit/functions/test_trigger_sf.py
+++ b/tests/unit/functions/test_trigger_sf.py
@@ -1,9 +1,12 @@
-import pytest
-from unittest.mock import patch
 import os
-import json
 import logging
+from unittest.mock import patch
+
+import pytest
 import aurora_data_api
+import boto3
+from moto import mock_stepfunctions
+
 from tests.helpers.utils import insert_records, rds_data_client
 from functions.trigger_sf import lambda_function
 
@@ -11,183 +14,166 @@ log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
 
-@patch.dict(
-    os.environ,
-    {
-        "REPO_FULL_NAME": "user/repo",
-        "AWS_REGION": "us-west-2",
-        "GITHUB_TOKEN_SSM_KEY": "mock-ssm-token-key",
-        "COMMIT_STATUS_CONFIG_SSM_KEY": "mock-ssm-config-key",
-        "STATE_MACHINE_ARN": "mock",
-        "GITHUB_MERGE_LOCK_SSM_KEY": "mock-ssm-key",
-    },
-)
 @pytest.mark.usefixtures("aws_credentials", "truncate_executions")
-@pytest.mark.parametrize(
-    "records,execution,expected_aborted_ids,expected_rollback_cfg_paths",
-    [
-        pytest.param(
-            [
-                {
-                    "execution_id": "run-foo",
-                    "status": "running",
-                    "is_rollback": False,
-                    "commit_id": "test-commit",
-                }
-            ],
-            {
-                "execution_id": "run-foo",
-                "status": "succeeded",
-                "is_rollback": False,
-                "commit_id": "test-commit",
-            },
-            [],
-            [],
-            id="succeeded_execution",
-        ),
-        pytest.param(
-            [
-                {
-                    "execution_id": "run-baz",
-                    "account_name": "dev",
-                    "cfg_path": "dev/baz",
-                    "status": "succeeded",
-                    "is_rollback": False,
-                    "commit_id": "test-commit",
-                    "new_providers": [],
-                    "new_resources": [],
-                },
-                {
-                    "execution_id": "run-zoo",
-                    "account_name": "dev",
-                    "cfg_path": "dev/zoo",
-                    "status": "running",
-                    "is_rollback": False,
-                    "commit_id": "test-commit",
-                    "new_providers": [],
-                    "new_resources": [],
-                },
-                {
-                    "execution_id": "run-bar",
-                    "account_name": "dev",
-                    "cfg_path": "dev/bar",
-                    "status": "succeeded",
-                    "is_rollback": False,
-                    "commit_id": "test-commit",
-                    "new_providers": ["hashicorp/null"],
-                    "new_resources": ["null_resource.this"],
-                },
-                {
-                    "execution_id": "run-foo",
-                    "status": "running",
-                    "is_rollback": False,
-                    "commit_id": "test-commit",
-                    "cfg_path": "dev/foo",
-                },
-            ],
-            {
-                "execution_id": "run-foo",
-                "status": "failed",
-                "is_rollback": False,
-                "commit_id": "test-commit",
-                "cfg_path": "dev/foo",
-            },
-            ["run-zoo"],
-            ["dev/bar"],
-            id="failed_execution",
-        ),
-        pytest.param(
-            [
-                {
-                    "execution_id": "run-foo",
-                    "status": "running",
-                    "is_rollback": True,
-                    "commit_id": "test-commit",
-                }
-            ],
-            {
-                "execution_id": "run-foo",
-                "status": "failed",
-                "is_rollback": True,
-                "commit_id": "test-commit",
-            },
-            [],
-            [],
-            id="failed_rollback_execution",
-        ),
-    ],
-)
-@patch("github.Github")
-@patch("functions.trigger_sf.lambda_function.ssm")
-@patch("functions.trigger_sf.lambda_function.sf")
-def test__execution_finished_status_update(
-    mock_sf,
-    mock_ssm,
-    mock_github,
-    records,
-    execution,
-    expected_aborted_ids,
-    expected_rollback_cfg_paths,
-):
-    """
-    Test to ensure that the finished execution's respective status was updated and
-    the function handles all possible execution statuses.
-    """
-    mock_ssm.get_parameter.return_value = {
-        "Parameter": {"Value": json.dumps({"Execution": True})}
-    }
+def test_execution_finished_update_status():
+    execution_id = "run-123"
+    expected_status = "success"
+    records = [{"execution_id": execution_id, "status": "running"}]
+    records = insert_records("executions", records, enable_defaults=True)
 
+    execution = lambda_function.ExecutionFinished(
+        execution_id=execution_id,
+        status=expected_status,
+        is_rollback="false",
+        commit_id="mock-commit",
+        cfg_path="/foo",
+    )
+    execution.update_status()
+
+    log.info("Assert finished execution record status was updated")
     with aurora_data_api.connect(
         database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
     ) as conn, conn.cursor() as cur:
-        mock_sf.list_executions.return_value = {
-            "executions": [
-                {"name": record["execution_id"], "executionArn": "mock-arn"}
-                for record in records
-                if record["status"] != "waiting"
-            ]
-        }
-        mock_sf.stop_execution.return_value = None
-        records = insert_records("executions", records, enable_defaults=True)
-
-        try:
-            lambda_function._execution_finished(cur, execution, 000000000000)
-        except lambda_function.ClientException as e:
-            # expects lambda to error if execution was a rollback and wasn't successful
-            if not execution["is_rollback"] and execution["status"] not in [
-                "aborted",
-                "failed",
-            ]:
-                raise (e)
-
-        log.info("Assert finished execution record status was updated")
         cur.execute(
             """
             SELECT status
             FROM executions
             WHERE execution_id = '{}'
             """.format(
-                execution["execution_id"]
+                execution_id
             )
         )
-        assert execution["status"] == cur.fetchone()[0]
+        actual_status = cur.fetchone()[0]
 
-        log.info("Assert Step Function executions were aborted")
+    assert actual_status == expected_status
+
+
+@pytest.mark.usefixtures("truncate_executions")
+def test_abort_commit_records():
+    commit_id = "test-commit"
+    records = [
+        {
+            "execution_id": "run-bar",
+            "account_name": "dev",
+            "cfg_path": "dev/bar",
+            "status": "running",
+            "is_rollback": False,
+            "commit_id": commit_id,
+        },
+        {
+            "execution_id": "run-foo",
+            "status": "waiting",
+            "is_rollback": False,
+            "commit_id": commit_id,
+            "cfg_path": "dev/foo",
+        },
+        {
+            "execution_id": "run-baz",
+            "status": "success",
+            "is_rollback": False,
+            "commit_id": commit_id,
+            "cfg_path": "dev/baz",
+        },
+    ]
+    insert_records("executions", records, enable_defaults=True)
+
+    execution = lambda_function.ExecutionFinished(
+        execution_id="run-123",
+        status="failed",
+        is_rollback="false",
+        commit_id=commit_id,
+        cfg_path="/foo",
+    )
+    execution.abort_commit_records()
+
+    with aurora_data_api.connect(
+        database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+    ) as conn, conn.cursor() as cur:
         cur.execute(
             """
             SELECT execution_id
             FROM executions
             WHERE commit_id = '{}'
-            AND status = 'aborted'
+            AND "status" IN ('waiting', 'running')
         """.format(
-                execution["commit_id"]
+                commit_id
             )
         )
-        res = [val[0] for val in cur.fetchall()]
-        log.debug(f"Actual: {res}")
-        assert all(path in res for path in expected_aborted_ids) is True
+        in_progress_ids = [val[0] for val in cur.fetchall() if val[0] is not None]
 
-        log.info("Assert rollback execution records were created")
+        log.info("Assert no execution has a waiting or running status")
+        assert len(in_progress_ids) == 0
+
+
+@mock_stepfunctions
+def test_abort_sf_executions():
+    execution_id = "run-123"
+    sf = boto3.client("stepfunctions")
+
+    machine_arn = sf.create_state_machine(
+        name="mock-machine",
+        definition="string",
+        roleArn="arn:aws:iam::123456789012:role/machine-role",
+    )["stateMachineArn"]
+
+    execution_arn = sf.start_execution(stateMachineArn=machine_arn, name=execution_id)[
+        "executionArn"
+    ]
+
+    execution = lambda_function.ExecutionFinished(
+        execution_id=execution_id,
+        status="failed",
+        is_rollback="false",
+        commit_id="mock-commit",
+        cfg_path="/foo",
+    )
+
+    with patch.dict(os.environ, {"STATE_MACHINE_ARN": machine_arn}):
+        # TODO: figure out how mock sf client with moto client to allow module-scope client in lambda file
+        with patch("boto3.client") as mock_sf:
+            mock_sf.return_value = sf
+            execution.abort_sf_executions([execution_id])
+
+    assert sf.describe_execution(executionArn=execution_arn)["status"] == "ABORTED"
+
+
+@pytest.mark.usefixtures("aws_credentials", "truncate_executions")
+def test_create_rollback_records():
+    commit_id = "test-commit"
+    expected_rollback_cfg_paths = ["dev/bar"]
+    records = [
+        {
+            "execution_id": "run-bar",
+            "account_name": "dev",
+            "cfg_path": expected_rollback_cfg_paths[0],
+            "status": "succeeded",
+            "is_rollback": False,
+            "commit_id": commit_id,
+            "new_providers": ["hashicorp/null"],
+            "new_resources": ["null_resource.this"],
+        },
+        {
+            "execution_id": "run-foo",
+            "status": "running",
+            "is_rollback": False,
+            "commit_id": commit_id,
+            "cfg_path": "dev/foo",
+        },
+    ]
+    insert_records("executions", records, enable_defaults=True)
+
+    execution = lambda_function.ExecutionFinished(
+        execution_id="run-123",
+        status="failed",
+        is_rollback="false",
+        commit_id=commit_id,
+        cfg_path="/foo",
+    )
+    execution.create_rollback_records()
+
+    with aurora_data_api.connect(
+        database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
+    ) as conn, conn.cursor() as cur:
         cur.execute(
             """
             SELECT cfg_path
@@ -195,23 +181,30 @@ def test__execution_finished_status_update(
             WHERE commit_id = '{}'
             AND is_rollback = true
         """.format(
-                execution["commit_id"]
+                commit_id
             )
         )
-        res = [val[0] for val in cur.fetchall()]
-        log.debug(f"Actual: {res}")
-        assert all(path in res for path in expected_rollback_cfg_paths) is True
+        actual = [val[0] for val in cur.fetchall()]
+
+        log.info("Assert rollback execution records were created")
+        for path in expected_rollback_cfg_paths:
+            assert path in actual
 
 
-@patch("functions.trigger_sf.lambda_function.sf")
-@patch.dict(
-    os.environ,
-    {
-        "COMMIT_STATUS_CONFIG_SSM_KEY": "mock-ssm-config-key",
-        "STATE_MACHINE_ARN": "mock",
-        "GITHUB_MERGE_LOCK_SSM_KEY": "mock-ssm-key",
-    },
-)
+def test_handle_failed_execution_is_rollback():
+    execution = lambda_function.ExecutionFinished(
+        execution_id="run-123",
+        status="failed",
+        is_rollback="true",
+        commit_id="mock-commit",
+        cfg_path="/foo",
+    )
+
+    with pytest.raises(lambda_function.ClientException):
+        execution.handle_failed_execution()
+
+
+@patch.dict(os.environ, {"STATE_MACHINE_ARN": "mock"})
 @pytest.mark.usefixtures("aws_credentials", "truncate_executions")
 @pytest.mark.parametrize(
     "records,expected_running_ids",
@@ -352,15 +345,14 @@ def test__execution_finished_status_update(
         ),
     ],
 )
-def test__start_executions(mock_sf, records, expected_running_ids):
+@pytest.mark.usefixtures("aws_credentials", "truncate_executions")
+@patch("functions.trigger_sf.lambda_function.sf")
+def test_start_executions(mock_sf, records, expected_running_ids):
     """Test to ensure that the Lambda Function handles account and directory level dependencies before starting any Step Function executions"""
 
     records = insert_records("executions", records, enable_defaults=True)
 
-    with aurora_data_api.connect(
-        database=os.environ["METADB_NAME"], rds_data_client=rds_data_client
-    ) as conn, conn.cursor() as cur:
-        lambda_function._start_sf_executions(cur)
+    lambda_function.start_sf_executions()
 
     log.info("Assert started Step Function execution statuses were updated to running")
     with aurora_data_api.connect(

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -3,3 +3,4 @@ awscli
 boto3
 aurora-data-api
 request-filter-groups
+moto


### PR DESCRIPTION
Related to issue #22

All core logic has been abstracted from the main lambda_handler() and separated into smaller, easier-to-unit test components.

Tests have been updated to include these new smaller functions.