### PR TITLE
Lambda receiver Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,6 @@
 name: Publish Docker image
 
 on:
-  release:
-    types: [published]
-    paths:
-    - docker/**
-    - .github/workflows/build.yml
   push:
     branches:
     - master
@@ -14,15 +9,31 @@ on:
     - tests
     paths:
     - docker/**
+    - functions/webhook_receiver/**
+    - .github/workflows/build.yml
+
+  release:
+    types: [published]
+    paths:
+    - docker/**
+    - functions/webhook_receiver/**
     - .github/workflows/build.yml
 
 jobs:
-  push_to_registry:
-    name: Push Docker image to GitHub Container Registry
+  ecs_task:
+    name: Push ECS task Docker image to GitHub Container Registry
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v34
+      with:
+        files: |
+          docker/**
 
     - name: Log into GitHub Container Registry
       uses: docker/login-action@v2
@@ -31,6 +42,16 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Build and push Docker master image
+      uses: docker/build-push-action@v3
+      if: ${{ (github.event_name == 'push') && (steps.changed-files.outputs.any_changed == 'true') }}
+      with:
+        context: docker
+        push: true
+        tags: |-
+          ghcr.io/${{ github.repository }}:latest
+          ghcr.io/${{ github.repository }}:${{ github.sha }}
+
     - name: Build and push Docker release image
       uses: docker/build-push-action@v3
       if: ${{ github.event_name == 'release' }}
@@ -38,14 +59,45 @@ jobs:
         context: docker
         push: true
         tags: |
-          ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
+          ghcr.io/${{ github.repository }}/tasks:${{ github.event.release.tag_name }}
+
+  receiver:
+    name: Push Lambda Receiver Docker image to GitHub Container Registry
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v34
+      with:
+        files: |
+          functions/webhook_receiver/**
+
+    - name: Log into GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push Docker master image
       uses: docker/build-push-action@v3
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ (github.event_name == 'push') && (steps.changed-files.outputs.any_changed == 'true') }}
       with:
-        context: docker
+        context: functions/webhook_receiver
         push: true
         tags: |-
           ghcr.io/${{ github.repository }}:latest
           ghcr.io/${{ github.repository }}:${{ github.sha }}
+
+    - name: Build and push Docker release image
+      uses: docker/build-push-action@v3
+      if: ${{ github.event_name == 'release' }}
+      with:
+        context: functions/webhook_receiver
+        push: true
+        tags: |
+          ghcr.io/${{ github.repository }}/tasks:${{ github.event.release.tag_name }}

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Terraform module that provisions an AWS serverless CI/CD pipeline used for manag
 | <a name="input_terragrunt_version"></a> [terragrunt\_version](#input\_terragrunt\_version) | Terragrunt version used for create\_deploy\_stack and terra\_run tasks.<br>Version must be >= `0.31.0`.<br>If repo contains a variety of version constraints, implementing a <br>version manager is recommended (e.g. tgswitch). | `string` | `""` | no |
 | <a name="input_tf_state_read_access_policy"></a> [tf\_state\_read\_access\_policy](#input\_tf\_state\_read\_access\_policy) | AWS IAM policy ARN that allows create deploy stack ECS task to read from Terraform remote state resource | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | AWS VPC ID to host the ECS container instances within.<br>The VPC should be associated with the subnet IDs specified under `var.ecs_subnet_ids` | `string` | n/a | yes |
+| <a name="input_webhook_receiver_image_address"></a> [webhook\_receiver\_image\_address](#input\_webhook\_receiver\_image\_address) | Docker registry image to use for the webhok receiver Lambda Function. If not specified, this Terraform module's GitHub registry image<br>will be used with the tag associated with the version of this module. | `string` | `null` | no |
 
 ## Outputs
 

--- a/common.tf
+++ b/common.tf
@@ -9,6 +9,8 @@ locals {
     Execution         = true
   })
   commit_status_config_name = "${var.prefix}-commit-status-config"
+  terraform_module_version  = trimspace(file("${path.module}/source_version.txt"))
+  module_docker_img_tag     = local.terraform_module_version == "master" ? "latest" : local.terraform_module_version
 }
 
 data "aws_region" "current" {}

--- a/fargate.tf
+++ b/fargate.tf
@@ -71,11 +71,9 @@ locals {
     },
   ]
 
-  terraform_module_version = trimspace(file("${path.module}/source_version.txt"))
-
   ecs_image_address = coalesce(
     var.ecs_image_address,
-    "ghcr.io/marshall7m/terraform-aws-infrastructure-live:${local.terraform_module_version == "master" ? "latest" : local.terraform_module_version}"
+    "ghcr.io/marshall7m/terraform-aws-infrastructure-live:${local.module_docker_img_tag}"
   )
 }
 

--- a/functions/webhook_receiver/Dockerfile
+++ b/functions/webhook_receiver/Dockerfile
@@ -1,0 +1,12 @@
+FROM public.ecr.aws/lambda/python:3.9
+
+COPY requirements.txt  .
+RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
+COPY lambda_function.py ${LAMBDA_TASK_ROOT}
+COPY models.py ${LAMBDA_TASK_ROOT}
+COPY invoker.py ${LAMBDA_TASK_ROOT}
+COPY exceptions.py ${LAMBDA_TASK_ROOT}
+COPY utils.py ${LAMBDA_TASK_ROOT}
+
+CMD [ "lambda_function.handler" ]

--- a/functions/webhook_receiver/invoker.py
+++ b/functions/webhook_receiver/invoker.py
@@ -8,8 +8,8 @@ import sys
 import boto3
 import github
 
-sys.path.append(os.path.dirname(__file__) + "/..")
-from common_lambda.utils import aws_encode, ServerException  # noqa E402
+sys.path.append(os.path.dirname(__file__))
+from utils import aws_encode, ServerException  # noqa E402
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/functions/webhook_receiver/models.py
+++ b/functions/webhook_receiver/models.py
@@ -6,7 +6,6 @@ import hmac
 import hashlib
 import re
 
-
 import github
 import boto3
 from pydantic import (
@@ -18,11 +17,9 @@ from pydantic import (
     Json,
 )
 
-sys.path.append(os.path.dirname(__file__) + "/..")
-from common_lambda.utils import aws_encode  # noqa E402
-
 sys.path.append(os.path.dirname(__file__))
 from exceptions import InvalidSignatureError, FilePathsNotMatched
+from utils import aws_encode
 
 
 class Headers(BaseModel):

--- a/functions/webhook_receiver/requirements.txt
+++ b/functions/webhook_receiver/requirements.txt
@@ -2,3 +2,4 @@ PyGithub==1.54.1
 mangum==0.15.1
 pydantic==1.10.2
 fastapi==0.85.1
+boto3==1.26.0

--- a/functions/webhook_receiver/utils.py
+++ b/functions/webhook_receiver/utils.py
@@ -1,0 +1,98 @@
+import hashlib
+import hmac
+import re
+import urllib.parse
+import urllib
+import logging
+
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+
+class ClientException(Exception):
+    """Wraps around client-related errors"""
+
+    pass
+
+
+class ServerException(Exception):
+    """Wraps around server-related errors"""
+
+    pass
+
+
+def aws_encode(value):
+    """Encodes value into AWS friendly URL component"""
+    value = urllib.parse.quote_plus(value)
+    value = re.sub(r"\+", " ", value)
+    return re.sub(r"%", "$", urllib.parse.quote_plus(value))
+
+
+def aws_decode(value):
+    """Decodes AWS friendly URL component"""
+    value = urllib.parse.unquote_plus(re.sub(r"\$", "%", value))
+    value = re.sub(r"\s", "+", value)
+    return urllib.parse.unquote_plus(value)
+
+
+def aws_response(
+    response, status_code=200, content_type="application/json", isBase64Encoded=False
+):
+    if isinstance(response, str):
+        return {
+            "statusCode": status_code,
+            "body": response,
+            "headers": {"content-type": content_type},
+            "isBase64Encoded": isBase64Encoded,
+        }
+
+    elif isinstance(response, dict):
+        return {
+            "statusCode": response.get("statusCode", status_code),
+            "body": str(response.get("body", "")),
+            "headers": {"content-type": response.get("content-type", content_type)},
+            "isBase64Encoded": response.get("isBase64Encoded", isBase64Encoded),
+        }
+
+    elif isinstance(response, Exception):
+        return {
+            "statusCode": 500,
+            "body": str(response),
+            "headers": {"content-type": content_type},
+            "isBase64Encoded": isBase64Encoded,
+        }
+
+
+def get_email_approval_sig(
+    secret, execution_id: str, recipient: str, action: str
+) -> str:
+    """
+    Returns signature used to authenticate AWS SES approval requests
+
+    Arguments:
+        execution_id: Step Function execution ID
+        recipient: Email address associated with the approval request
+        action: Approval action (e.g. approve, reject)
+    """
+    data = execution_id + recipient + action
+    sig = hmac.new(
+        bytes(str(secret), "utf-8"), bytes(str(data), "utf-8"), hashlib.sha256
+    ).hexdigest()
+
+    return sig
+
+
+def validate_sig(actual_sig: str, expected_sig: str):
+    """
+    Authenticates request by comparing the request's SHA256
+    signature value to the expected SHA-256 value
+    """
+
+    log.debug(f"Actual: {actual_sig}")
+    log.debug(f"Expected: {expected_sig}")
+
+    authorized = hmac.compare_digest(str(actual_sig), str(expected_sig))
+
+    if not authorized:
+        raise ClientException("Header signature and expected signature do not match")

--- a/merge_status_checks.tf
+++ b/merge_status_checks.tf
@@ -113,16 +113,13 @@ module "lambda_webhook_receiver" {
   authorization_type         = "NONE"
   create_lambda_function_url = true
 
-  source_path = [
-    {
-      path             = "${path.module}/functions/webhook_receiver"
-      pip_requirements = true
-    },
-    {
-      path          = "${path.module}/functions/common_lambda"
-      prefix_in_zip = "common_lambda"
-    }
-  ]
+  image_uri = coalesce(
+    var.webhook_receiver_image_address,
+    "ghcr.io/marshall7m/terraform-aws-infrastructure-live/webhook-receiver:${local.module_docker_img_tag}"
+  )
+  create_package = false
+  package_type   = "Image"
+  architectures  = ["x86_64"]
 
   environment_variables = {
     GITHUB_TOKEN_SSM_KEY          = local.github_token_ssm_key

--- a/tests/fixtures/terraform/mut/basic/main.tf
+++ b/tests/fixtures/terraform/mut/basic/main.tf
@@ -38,6 +38,8 @@ module "mut_infrastructure_live_ci" {
   registry_password              = var.registry_password
   ecs_image_address              = var.ecs_image_address
 
+  webhook_receiver_image_address = var.webhook_receiver_image_address
+
   # repo specific env vars required to conditionally set the terraform backend configurations
   ecs_tasks_common_env_vars = concat([
     {

--- a/tests/fixtures/terraform/mut/basic/variables.tf
+++ b/tests/fixtures/terraform/mut/basic/variables.tf
@@ -163,6 +163,15 @@ EOF
   default     = null
 }
 
+variable "webhook_receiver_image_address" {
+  description = <<EOF
+Docker registry image to use for the webhok receiver Lambda Function. If not specified, this Terraform module's GitHub registry image
+will be used with the tag associated with the version of this module. 
+EOF
+  type        = string
+  default     = null
+}
+
 variable "local_task_common_env_vars" {
   description = "ECS task env vars to set for local testing terraform module"
   type = list(object({

--- a/variables.tf
+++ b/variables.tf
@@ -430,6 +430,15 @@ EOF
   default = null
 }
 
+variable "webhook_receiver_image_address" {
+  description = <<EOF
+Docker registry image to use for the webhok receiver Lambda Function. If not specified, this Terraform module's GitHub registry image
+will be used with the tag associated with the version of this module. 
+EOF
+  type        = string
+  default     = null
+}
+
 variable "private_registry_auth" {
   description = "Determines if authentification is required to pull the docker images used by the ECS tasks"
   type        = bool


### PR DESCRIPTION
PR introduces the use of a Dockerfile to create the Lambda Function receiver artifact instead of a zip file. This allows the testing environment to be isolated from the Lambda Function container which prevents any dependency issues across machines.