### PR TITLE
add -no-color tf flag to plan/apply cmds

### DIFF
--- a/docker/src/create_deploy_stack/sql/update_executions_with_new_deploy_stack.sql
+++ b/docker/src/create_deploy_stack/sql/update_executions_with_new_deploy_stack.sql
@@ -47,9 +47,9 @@ SELECT  -- noqa: L034, L036
     '{apply_role_arn}',
     {pr_id},  -- noqa: L019
     'terragrunt plan --terragrunt-working-dir ' || stack.cfg_path
-    || ' --terragrunt-iam-role ' || '{plan_role_arn}',
+    || ' --terragrunt-iam-role ' || '{plan_role_arn}' || ' -no-color',
     'terragrunt apply --terragrunt-working-dir ' || stack.cfg_path
-    || ' --terragrunt-iam-role ' || '{apply_role_arn}' || ' -auto-approve'
+    || ' --terragrunt-iam-role ' || '{apply_role_arn}' || ' -no-color -auto-approve'
 FROM (
     VALUES {stack}
 ) stack(cfg_path, cfg_deps, new_providers)  -- noqa: L011, L025

--- a/functions/trigger_sf/sql/update_executions_with_new_rollback_stack.sql
+++ b/functions/trigger_sf/sql/update_executions_with_new_rollback_stack.sql
@@ -99,11 +99,11 @@ FROM (
         'terragrunt plan --terragrunt-working-dir ' || cfg_path
         || ' --terragrunt-iam-role ' || plan_role_arn || target_resources(
             new_resources
-        ) || ' -destroy' AS plan_command,
+        ) || ' -no-color' -destroy' AS plan_command,
         'terragrunt destroy --terragrunt-working-dir ' || cfg_path
         || ' --terragrunt-iam-role ' || apply_role_arn || target_resources(
             new_resources
-        ) || ' -auto-approve' AS apply_command
+        ) || ' -no-color -auto-approve' AS apply_command
     FROM executions
     WHERE commit_id = '{commit_id}'
           AND cardinality(new_resources) > 0


### PR DESCRIPTION
- Using `-no-color` flag within Terraform plan and apply commands fixes output formatting within CloudWatch logs